### PR TITLE
make decisions by evaluating policy

### DIFF
--- a/Nudge/OSVersion.swift
+++ b/Nudge/OSVersion.swift
@@ -48,6 +48,10 @@ extension OSVersion: CustomStringConvertible {
     }
 }
 
+extension OSVersion: Codable {
+    // TODO: add json
+}
+
 extension OSVersion: Equatable {
     public static func == (lhs: OSVersion, rhs: OSVersion) -> Bool {
         return (lhs.major, lhs.minor, lhs.patch) == (rhs.major, rhs.minor, rhs.patch)

--- a/Nudge/nudgePrefs.swift
+++ b/Nudge/nudgePrefs.swift
@@ -223,7 +223,7 @@ extension MdmFeatures {
 struct OSVersionRequirement: Codable {
     let majorUpgradeAppPath: String
     let requiredInstallationDate: Date
-    let requiredMinimumOSVersion: String
+    let requiredMinimumOSVersion: OSVersion
     let requiredMinimumOSVersionBuild: String // TODO: should be a list, in case of forked builds
     let targetedOSVersions: [String]
 }
@@ -265,7 +265,7 @@ extension OSVersionRequirement {
     func with(
         majorUpgradeAppPath: String? = nil,
         requiredInstallationDate: Date? = nil,
-        requiredMinimumOSVersion: String? = nil,
+        requiredMinimumOSVersion: OSVersion? = nil,
         requiredMinimumOSVersionBuild: String? = nil,
         targetedOSVersions: [String]? = nil
     ) -> OSVersionRequirement {

--- a/Nudge/osUtils.swift
+++ b/Nudge/osUtils.swift
@@ -16,7 +16,7 @@ struct osUtils {
         Date()
     }
     
-    func getRequiredMinimumOSVersion() -> String? {
+    func getRequiredMinimumOSVersion() -> OSVersion? {
         // TODO: Need to make this dynamic instead of hardcoded to the first value
         return nudgePreferences!.osVersionRequirements[0].requiredMinimumOSVersion
     }
@@ -89,13 +89,15 @@ struct osUtils {
     func getPatchOSVersion() -> Int {
         return ProcessInfo().operatingSystemVersion.patchVersion
     }
-    
+  
+    /*
     func getMajorRequiredNudgeOSVersion() -> Int {
         let nudgePreferences = nudgePrefs().loadNudgePrefs()
         // TODO: Need to make this dynamic instead of hardcoded to the first value
         let parts = nudgePreferences!.osVersionRequirements[0].requiredMinimumOSVersion.split(separator: ".", omittingEmptySubsequences: false)
         return Int(parts[0])!
     }
+ */
 
     // Why is there not a combined String for this?
     func getOSVersion() -> String {


### PR DESCRIPTION
Picks the required update from configuration and compares the system
against it. Returns an action as a result.

I refactored the string typed version in config to be a OSVersion, which
allows everything to be easily comparable. In the process I ended up
cutting some corners with the current globals. The changes are having a
domino effect where it's hard to change one thing without changing a
dozen other helpers in osutils/nudge.

Don't merge this yet/leaving for discussion before we decide to do
bigger changes or take a different approach.