### PR TITLE
Add logic for noTimers and randomDelay

### DIFF
--- a/Nudge/ContentView.swift
+++ b/Nudge/ContentView.swift
@@ -36,8 +36,16 @@ struct HostingWindowFinder: NSViewRepresentable {
 
     func makeNSView(context: Self.Context) -> NSView {
         let view = NSView()
-        DispatchQueue.main.async { [weak view] in
-            self.callback(view?.window)
+        if randomDelay {
+            let randomDelaySeconds = Int.random(in: 1...maxRandomDelayInSeconds)
+            print("Delaying initial run by", String(randomDelaySeconds), "seconds...")
+            DispatchQueue.main.asyncAfter(deadline: .now() + Double(randomDelaySeconds)) { [weak view] in
+                self.callback(view?.window)
+            }
+        } else {
+            DispatchQueue.main.async { [weak view] in
+                self.callback(view?.window)
+            }
         }
         return view
     }

--- a/Nudge/Nudge.swift
+++ b/Nudge/Nudge.swift
@@ -474,6 +474,11 @@ func updateDevice() {
 }
 
 func needToActivateNudge(deferralCount: Int, lastRefreshTimeVar: Date) -> Bool {
+    // If noTimers is true, just bail
+    if noTimers {
+        return false
+    }
+    
     let currentTime = Date().timeIntervalSince1970
     let timeDiff = Int((currentTime - lastRefreshTimeVar.timeIntervalSince1970))
 

--- a/Nudge/defaultUIPreferences.swift
+++ b/Nudge/defaultUIPreferences.swift
@@ -20,6 +20,7 @@ let enforceMinorUpdates = nudgePreferences?.optionalFeatures?.enforceMinorUpdate
 let iconDarkPath = nudgePreferences?.optionalFeatures?.iconDarkPath ?? ""
 let iconLightPath = nudgePreferences?.optionalFeatures?.iconLightPath ?? ""
 let informationButtonPath = nudgePreferences?.optionalFeatures?.informationButtonPath ?? "https://github.com/erikng/NudgeSwift"
+let maxRandomDelayInSeconds = nudgePreferences?.optionalFeatures?.maxRandomDelayInSeconds ?? 1200
 let noTimers = nudgePreferences?.optionalFeatures?.noTimers ?? false
 let randomDelay = nudgePreferences?.optionalFeatures?.randomDelay ?? false
 let screenShotPath = nudgePreferences?.optionalFeatures?.screenShotPath ?? ""

--- a/Nudge/example.json
+++ b/Nudge/example.json
@@ -18,6 +18,7 @@
             "mdmRequiredInstallationDate": "2021-02-28T00:00:00Z",
             "uamdmScreenShotPath": "/Library/Application Support/nudge/uamdmScreenShot.jpg"
         },
+        "maxRandomDelayInSeconds": 1200,
         "noTimers": false,
         "randomDelay": false,
         "screenShotPath": "/Library/Application Support/nudge/ScreenShot.jpg"

--- a/Nudge/nudgePrefs.swift
+++ b/Nudge/nudgePrefs.swift
@@ -91,6 +91,7 @@ struct OptionalFeatures: Codable {
     var attemptToFetchMajorUpgrade, enforceMinorUpdates: Bool?
     var iconDarkPath, iconLightPath: String?
     var informationButtonPath: String?
+    var maxRandomDelayInSeconds: Int?
     var mdmFeatures: MdmFeatures?
     var noTimers, randomDelay: Bool?
     var screenShotPath: String?
@@ -122,6 +123,7 @@ extension OptionalFeatures {
         iconDarkPath: String?? = nil,
         iconLightPath: String?? = nil,
         informationButtonPath: String?? = nil,
+        maxRandomDelayInSeconds: Int?? = nil,
         mdmFeatures: MdmFeatures?? = nil,
         noTimers: Bool?? = nil,
         randomDelay: Bool?? = nil,
@@ -135,6 +137,7 @@ extension OptionalFeatures {
             iconDarkPath: iconDarkPath ?? self.iconDarkPath,
             iconLightPath: iconLightPath ?? self.iconLightPath,
             informationButtonPath: informationButtonPath ?? self.informationButtonPath,
+            maxRandomDelayInSeconds: maxRandomDelayInSeconds ?? self.maxRandomDelayInSeconds,
             mdmFeatures: mdmFeatures ?? self.mdmFeatures,
             noTimers: noTimers ?? self.noTimers,
             randomDelay: randomDelay ?? self.randomDelay,


### PR DESCRIPTION
This also adds a new `maxRandomDelayInSeconds` key to control the max delay. The old nudge was hardcoded to 20 minutes.